### PR TITLE
Webサイトをカスタマイズできるようにする

### DIFF
--- a/Resources/IosOsushiTheme/styles.css
+++ b/Resources/IosOsushiTheme/styles.css
@@ -1,0 +1,169 @@
+/**
+*  Publish Foundation theme
+*  Copyright (c) John Sundell 2019
+*  MIT license, see LICENSE file for details
+*/
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background: #fff;
+    color: #000;
+    font-family: Helvetica, Arial;
+    text-align: center;
+}
+
+.wrapper {
+    max-width: 900px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 40px;
+    text-align: left;
+}
+
+header {
+    background-color: #eee;
+}
+
+header .wrapper {
+    padding-top: 30px;
+    padding-bottom: 30px;
+    text-align: center;
+}
+
+header a {
+    text-decoration: none;
+}
+
+header .site-name {
+    font-size: 1.5em;
+    color: #000;
+    font-weight: bold;
+}
+
+nav {
+    margin-top: 20px;
+}
+
+nav li {
+    display: inline-block;
+    margin: 0 7px;
+    line-height: 1.5em;
+}
+
+nav li a.selected {
+    text-decoration: underline;
+}
+
+h1 {
+    margin-bottom: 20px;
+    font-size: 2em;
+}
+
+h2 {
+    margin: 20px 0;
+}
+
+p {
+    margin-bottom: 10px;
+}
+
+a {
+    color: inherit;
+}
+
+.description {
+    margin-bottom: 40px;
+}
+
+.item-list > li {
+    display: block;
+    padding: 20px;
+    border-radius: 20px;
+    background-color: #eee;
+    margin-bottom: 20px;
+}
+
+.item-list > li:last-child {
+    margin-bottom: 0;
+}
+
+.item-list h1 {
+    margin-bottom: 15px;
+    font-size: 1.3em;
+}
+
+.item-list p {
+    margin-bottom: 0;
+}
+
+.tag-list {
+    margin-bottom: 15px;
+}
+
+.tag-list li,
+.tag {
+    display: inline-block;
+    background-color: #000;
+    color: #ddd;
+    padding: 4px 6px;
+    border-radius: 5px;
+    margin-right: 5px;
+}
+
+.tag-list a,
+.tag a {
+    text-decoration: none;
+}
+
+.item-page .tag-list {
+    display: inline-block;
+}
+
+.content {
+    margin-bottom: 40px;
+}
+
+.browse-all {
+    display: block;
+    margin-bottom: 30px;
+}
+
+.all-tags li {
+    font-size: 1.4em;
+    margin-right: 10px;
+    padding: 6px 10px;
+}
+
+footer {
+    color: #8a8a8a;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #222;
+    }
+
+    body,
+    header .site-name {
+        color: #ddd;
+    }
+
+    .item-list > li {
+        background-color: #333;
+    }
+
+    header {
+        background-color: #000;
+    }
+}
+
+@media(max-width: 600px) {
+    .wrapper {
+        padding: 40px 20px;
+    }
+}

--- a/Sources/IosOsushiWebsite/Theme+IosOsushi.swift
+++ b/Sources/IosOsushiWebsite/Theme+IosOsushi.swift
@@ -1,15 +1,13 @@
 /**
-*  Publish
-*  Copyright (c) John Sundell 2019
-*  MIT license, see LICENSE file for details
-*/
+ *  Publish
+ *  Copyright (c) John Sundell 2019
+ *  MIT license, see LICENSE file for details
+ */
 
 import Publish
 import Plot
 
 public extension Theme {
-    /// The default "Foundation" theme that Publish ships with, a very
-    /// basic theme mostly implemented for demonstration purposes.
     static var iosOsushi: Self {
         Theme(
             htmlFactory: IosOsushiHTMLFactory(),
@@ -19,8 +17,7 @@ public extension Theme {
 }
 
 private struct IosOsushiHTMLFactory<Site: Website>: HTMLFactory {
-    func makeIndexHTML(for index: Index,
-                       context: PublishingContext<Site>) throws -> HTML {
+    func makeIndexHTML(for index: Index, context: PublishingContext<Site>) throws -> HTML {
         HTML(
             .lang(context.site.language),
             .head(for: index, on: context.site),
@@ -44,8 +41,7 @@ private struct IosOsushiHTMLFactory<Site: Website>: HTMLFactory {
         )
     }
 
-    func makeSectionHTML(for section: Section<Site>,
-                         context: PublishingContext<Site>) throws -> HTML {
+    func makeSectionHTML(for section: Section<Site>, context: PublishingContext<Site>) throws -> HTML {
         HTML(
             .lang(context.site.language),
             .head(for: section, on: context.site),
@@ -60,8 +56,7 @@ private struct IosOsushiHTMLFactory<Site: Website>: HTMLFactory {
         )
     }
 
-    func makeItemHTML(for item: Item<Site>,
-                      context: PublishingContext<Site>) throws -> HTML {
+    func makeItemHTML(for item: Item<Site>, context: PublishingContext<Site>) throws -> HTML {
         HTML(
             .lang(context.site.language),
             .head(for: item, on: context.site),
@@ -82,8 +77,7 @@ private struct IosOsushiHTMLFactory<Site: Website>: HTMLFactory {
         )
     }
 
-    func makePageHTML(for page: Page,
-                      context: PublishingContext<Site>) throws -> HTML {
+    func makePageHTML(for page: Page, context: PublishingContext<Site>) throws -> HTML {
         HTML(
             .lang(context.site.language),
             .head(for: page, on: context.site),
@@ -95,8 +89,7 @@ private struct IosOsushiHTMLFactory<Site: Website>: HTMLFactory {
         )
     }
 
-    func makeTagListHTML(for page: TagListPage,
-                         context: PublishingContext<Site>) throws -> HTML? {
+    func makeTagListHTML(for page: TagListPage, context: PublishingContext<Site>) throws -> HTML? {
         HTML(
             .lang(context.site.language),
             .head(for: page, on: context.site),
@@ -106,9 +99,7 @@ private struct IosOsushiHTMLFactory<Site: Website>: HTMLFactory {
                     H1("Browse all tags")
                     List(page.tags.sorted()) { tag in
                         ListItem {
-                            Link(tag.string,
-                                 url: context.site.path(for: tag).absoluteString
-                            )
+                            Link(tag.string, url: context.site.path(for: tag).absoluteString)
                         }
                         .class("tag")
                     }
@@ -119,8 +110,7 @@ private struct IosOsushiHTMLFactory<Site: Website>: HTMLFactory {
         )
     }
 
-    func makeTagDetailsHTML(for page: TagDetailsPage,
-                            context: PublishingContext<Site>) throws -> HTML? {
+    func makeTagDetailsHTML(for page: TagDetailsPage, context: PublishingContext<Site>) throws -> HTML? {
         HTML(
             .lang(context.site.language),
             .head(for: page, on: context.site),
@@ -133,7 +123,7 @@ private struct IosOsushiHTMLFactory<Site: Website>: HTMLFactory {
                     }
 
                     Link("Browse all tags",
-                        url: context.site.tagListPath.absoluteString
+                         url: context.site.tagListPath.absoluteString
                     )
                     .class("browse-all")
 
@@ -182,10 +172,8 @@ private struct SiteHeader<Site: Website>: Component {
             List(Site.SectionID.allCases) { sectionID in
                 let section = context.sections[sectionID]
 
-                return Link(section.title,
-                    url: section.path.absoluteString
-                )
-                .class(sectionID == selectedSelectionID ? "selected" : "")
+                return Link(section.title, url: section.path.absoluteString)
+                    .class(sectionID == selectedSelectionID ? "selected" : "")
             }
         }
     }

--- a/Sources/IosOsushiWebsite/Theme+IosOsushi.swift
+++ b/Sources/IosOsushiWebsite/Theme+IosOsushi.swift
@@ -122,8 +122,7 @@ private struct IosOsushiHTMLFactory<Site: Website>: HTMLFactory {
                         Span(page.tag.string).class("tag")
                     }
 
-                    Link("Browse all tags",
-                         url: context.site.tagListPath.absoluteString
+                    Link("Browse all tags", url: context.site.tagListPath.absoluteString
                     )
                     .class("browse-all")
 

--- a/Sources/IosOsushiWebsite/Theme+IosOsushi.swift
+++ b/Sources/IosOsushiWebsite/Theme+IosOsushi.swift
@@ -1,0 +1,234 @@
+/**
+*  Publish
+*  Copyright (c) John Sundell 2019
+*  MIT license, see LICENSE file for details
+*/
+
+import Publish
+import Plot
+
+public extension Theme {
+    /// The default "Foundation" theme that Publish ships with, a very
+    /// basic theme mostly implemented for demonstration purposes.
+    static var iosOsushi: Self {
+        Theme(
+            htmlFactory: IosOsushiHTMLFactory(),
+            resourcePaths: ["Resources/IosOsushiTheme/styles.css"]
+        )
+    }
+}
+
+private struct IosOsushiHTMLFactory<Site: Website>: HTMLFactory {
+    func makeIndexHTML(for index: Index,
+                       context: PublishingContext<Site>) throws -> HTML {
+        HTML(
+            .lang(context.site.language),
+            .head(for: index, on: context.site),
+            .body {
+                SiteHeader(context: context, selectedSelectionID: nil)
+                Wrapper {
+                    H1(index.title)
+                    Paragraph(context.site.description)
+                        .class("description")
+                    H2("Latest content")
+                    ItemList(
+                        items: context.allItems(
+                            sortedBy: \.date,
+                            order: .descending
+                        ),
+                        site: context.site
+                    )
+                }
+                SiteFooter()
+            }
+        )
+    }
+
+    func makeSectionHTML(for section: Section<Site>,
+                         context: PublishingContext<Site>) throws -> HTML {
+        HTML(
+            .lang(context.site.language),
+            .head(for: section, on: context.site),
+            .body {
+                SiteHeader(context: context, selectedSelectionID: section.id)
+                Wrapper {
+                    H1(section.title)
+                    ItemList(items: section.items, site: context.site)
+                }
+                SiteFooter()
+            }
+        )
+    }
+
+    func makeItemHTML(for item: Item<Site>,
+                      context: PublishingContext<Site>) throws -> HTML {
+        HTML(
+            .lang(context.site.language),
+            .head(for: item, on: context.site),
+            .body(
+                .class("item-page"),
+                .components {
+                    SiteHeader(context: context, selectedSelectionID: item.sectionID)
+                    Wrapper {
+                        Article {
+                            Div(item.content.body).class("content")
+                            Span("Tagged with: ")
+                            ItemTagList(item: item, site: context.site)
+                        }
+                    }
+                    SiteFooter()
+                }
+            )
+        )
+    }
+
+    func makePageHTML(for page: Page,
+                      context: PublishingContext<Site>) throws -> HTML {
+        HTML(
+            .lang(context.site.language),
+            .head(for: page, on: context.site),
+            .body {
+                SiteHeader(context: context, selectedSelectionID: nil)
+                Wrapper(page.body)
+                SiteFooter()
+            }
+        )
+    }
+
+    func makeTagListHTML(for page: TagListPage,
+                         context: PublishingContext<Site>) throws -> HTML? {
+        HTML(
+            .lang(context.site.language),
+            .head(for: page, on: context.site),
+            .body {
+                SiteHeader(context: context, selectedSelectionID: nil)
+                Wrapper {
+                    H1("Browse all tags")
+                    List(page.tags.sorted()) { tag in
+                        ListItem {
+                            Link(tag.string,
+                                 url: context.site.path(for: tag).absoluteString
+                            )
+                        }
+                        .class("tag")
+                    }
+                    .class("all-tags")
+                }
+                SiteFooter()
+            }
+        )
+    }
+
+    func makeTagDetailsHTML(for page: TagDetailsPage,
+                            context: PublishingContext<Site>) throws -> HTML? {
+        HTML(
+            .lang(context.site.language),
+            .head(for: page, on: context.site),
+            .body {
+                SiteHeader(context: context, selectedSelectionID: nil)
+                Wrapper {
+                    H1 {
+                        Text("Tagged with ")
+                        Span(page.tag.string).class("tag")
+                    }
+
+                    Link("Browse all tags",
+                        url: context.site.tagListPath.absoluteString
+                    )
+                    .class("browse-all")
+
+                    ItemList(
+                        items: context.items(
+                            taggedWith: page.tag,
+                            sortedBy: \.date,
+                            order: .descending
+                        ),
+                        site: context.site
+                    )
+                }
+                SiteFooter()
+            }
+        )
+    }
+}
+
+private struct Wrapper: ComponentContainer {
+    @ComponentBuilder var content: ContentProvider
+
+    var body: Component {
+        Div(content: content).class("wrapper")
+    }
+}
+
+private struct SiteHeader<Site: Website>: Component {
+    var context: PublishingContext<Site>
+    var selectedSelectionID: Site.SectionID?
+
+    var body: Component {
+        Header {
+            Wrapper {
+                Link(context.site.name, url: "/")
+                    .class("site-name")
+
+                if Site.SectionID.allCases.count > 1 {
+                    navigation
+                }
+            }
+        }
+    }
+
+    private var navigation: Component {
+        Navigation {
+            List(Site.SectionID.allCases) { sectionID in
+                let section = context.sections[sectionID]
+
+                return Link(section.title,
+                    url: section.path.absoluteString
+                )
+                .class(sectionID == selectedSelectionID ? "selected" : "")
+            }
+        }
+    }
+}
+
+private struct ItemList<Site: Website>: Component {
+    var items: [Item<Site>]
+    var site: Site
+
+    var body: Component {
+        List(items) { item in
+            Article {
+                H1(Link(item.title, url: item.path.absoluteString))
+                ItemTagList(item: item, site: site)
+                Paragraph(item.description)
+            }
+        }
+        .class("item-list")
+    }
+}
+
+private struct ItemTagList<Site: Website>: Component {
+    var item: Item<Site>
+    var site: Site
+
+    var body: Component {
+        List(item.tags) { tag in
+            Link(tag.string, url: site.path(for: tag).absoluteString)
+        }
+        .class("tag-list")
+    }
+}
+
+private struct SiteFooter: Component {
+    var body: Component {
+        Footer {
+            Paragraph {
+                Text("Generated using ")
+                Link("Publish", url: "https://github.com/johnsundell/publish")
+            }
+            Paragraph {
+                Link("RSS feed", url: "/feed.rss")
+            }
+        }
+    }
+}

--- a/Sources/IosOsushiWebsite/main.swift
+++ b/Sources/IosOsushiWebsite/main.swift
@@ -25,7 +25,7 @@ struct IosOsushiWebsite: Publish.Website {
 try IosOsushiWebsite().publish(using: [
     .addMarkdownFiles(),
     .copyResources(),
-    .generateHTML(withTheme: .foundation),
+    .generateHTML(withTheme: .iosOsushi),
     .generateRSSFeed(including: [.posts]),
     .generateSiteMap(),
     .deploy(using: .gitHub("ios-osushi/ios-osushi.github.io", useSSH: false))


### PR DESCRIPTION
## Issue

- close #8

## 概要

`foundation` テーマをそのままコピーして `iosOsushi` にリネームして整形しただけ。
MIT ライセンスなので問題ないはず。

テーマのカスタマイズは別 Issue で行う。