### PR TITLE
Fix unintentional horizontal scroll of content

### DIFF
--- a/Resources/IosOsushiTheme/styles.css
+++ b/Resources/IosOsushiTheme/styles.css
@@ -126,6 +126,7 @@ a {
 
 .content {
     margin-bottom: 40px;
+    overflow-wrap: break-word;
 }
 
 .browse-all {


### PR DESCRIPTION
Fix to avoid unintentional scroll of content, added `overflow-wrap: break-word` to the `.content`.

Before:

<img width="128" alt="image" src="https://user-images.githubusercontent.com/8467289/161431495-6fc619d6-2734-4212-9028-cb2ba7ab7d06.png">

After:

<img width="128" alt="image" src="https://user-images.githubusercontent.com/8467289/161431484-5630904d-6eb6-41c1-85b1-e579fb3c848f.png">

Lastly, thanks for all of your great work! I'm very excited to see the upcoming news!