### PR TITLE
レイアウトの調整

### DIFF
--- a/Resources/IosOsushiTheme/styles.css
+++ b/Resources/IosOsushiTheme/styles.css
@@ -66,7 +66,7 @@ h1 {
 
 h2, h3, h4, h5, h6 {
     margin-top: 30px;
-    margin-bottom: 20px;
+    margin-bottom: 15px;
     margin-left: 0;
     margin-right: 0;
 }

--- a/Resources/IosOsushiTheme/styles.css
+++ b/Resources/IosOsushiTheme/styles.css
@@ -146,6 +146,13 @@ a {
     line-height: 1.5em;
 }
 
+.content code {
+    padding: 0.1em 0.4em;
+    background-color: #eee;
+    border-radius: 4px;
+    font-family: Consolas, Menlo, Courier, monospace;
+}
+
 .browse-all {
     display: block;
     margin-bottom: 30px;

--- a/Resources/IosOsushiTheme/styles.css
+++ b/Resources/IosOsushiTheme/styles.css
@@ -182,6 +182,10 @@ footer {
     .item-list > li {
         background-color: #333;
     }
+    
+    .content code {
+        background-color: #333;
+    }
 
     header {
         background-color: #000;

--- a/Resources/IosOsushiTheme/styles.css
+++ b/Resources/IosOsushiTheme/styles.css
@@ -130,6 +130,19 @@ a {
     overflow-wrap: break-word;
 }
 
+.content > ul {
+    margin-top: 1.5em;
+    margin-bottom: 1.5em;
+}
+
+.content ul {
+    margin-left: 1.5em;
+}
+
+.content li {
+    line-height: 1.5em;
+}
+
 .browse-all {
     display: block;
     margin-bottom: 30px;

--- a/Resources/IosOsushiTheme/styles.css
+++ b/Resources/IosOsushiTheme/styles.css
@@ -64,8 +64,11 @@ h1 {
     font-size: 2em;
 }
 
-h2 {
-    margin: 20px 0;
+h2, h3, h4, h5, h6 {
+    margin-top: 30px;
+    margin-bottom: 20px;
+    margin-left: 0;
+    margin-right: 0;
 }
 
 p {


### PR DESCRIPTION
## 詳細

- 見出し（ `h1` 〜 `h6` ）のマージンを調整
- 箇条書きのマージンを調整
- `code` のフォントなどを調整

## スクリーンショット

|Before|After|
|:--:|:--:|
|![スクリーンショット 2022-05-03 1 00 56](https://user-images.githubusercontent.com/21194714/166266763-97e30ca4-ffb6-437a-ad51-a88d53bb1b56.png)|![スクリーンショット 2022-05-03 1 27 55](https://user-images.githubusercontent.com/21194714/166272696-8187b030-473a-44ba-8f9f-b713154c04f3.png)|

## 参考

- https://code-kitchen.dev/html/code/
- https://cdn.qiita.com/assets/public/article-c894370ec1508dc273e0b9250b400bd1.min.css