### PR TITLE
ワークフローの権限を明記する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/create_post.yml
+++ b/.github/workflows/create_post.yml
@@ -13,6 +13,7 @@ on:
         type: string
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/create_post.yml
+++ b/.github/workflows/create_post.yml
@@ -12,9 +12,13 @@ on:
         required: true 
         type: string
 
+permissions:
+  pull-requests: write
+
 jobs:
   create-post:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/create_post.yml
+++ b/.github/workflows/create_post.yml
@@ -65,4 +65,3 @@ jobs:
           --draft
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
- \

--- a/.github/workflows/create_post.yml
+++ b/.github/workflows/create_post.yml
@@ -59,9 +59,10 @@ jobs:
         gh --version
         gh pr create \
           --title "Create ${{ steps.create_post.outputs.post_filename }}" \
-          --body "## スクリーンショット\n\n| `${{ steps.create_post.outputs.post_filename }}` |\n|:--:|\n|TBD|"
+          --body "## スクリーンショット\n\n| `${{ steps.create_post.outputs.post_filename }}` |\n|:--:|\n|TBD|" \
           --base "${{ github.event.repository.default_branch }}" \
           --head "${{ steps.create_work_branch.outputs.work_branch_name }}" \
           --draft
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ \

--- a/.github/workflows/create_post.yml
+++ b/.github/workflows/create_post.yml
@@ -56,9 +56,10 @@ jobs:
 
     - name: Create pull request
       run: |
-        hub version
-        hub pull-request \
-          --message "Create ${{ steps.create_post.outputs.post_filename }}" \
+        gh --version
+        gh pr create \
+          --title "Create ${{ steps.create_post.outputs.post_filename }}" \
+          --body "## スクリーンショット\n\n| `${{ steps.create_post.outputs.post_filename }}` |\n|:--:|\n|TBD|"
           --base "${{ github.event.repository.default_branch }}" \
           --head "${{ steps.create_work_branch.outputs.work_branch_name }}" \
           --draft

--- a/.github/workflows/create_post.yml
+++ b/.github/workflows/create_post.yml
@@ -59,7 +59,6 @@ jobs:
         gh --version
         gh pr create \
           --title "Create ${{ steps.create_post.outputs.post_filename }}" \
-          --body "## スクリーンショット\n\n| `${{ steps.create_post.outputs.post_filename }}` |\n|:--:|\n|TBD|" \
           --base "${{ github.event.repository.default_branch }}" \
           --head "${{ steps.create_work_branch.outputs.work_branch_name }}" \
           --draft

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 23 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Issue

- close #45

## 詳細

- Organization と ios-osushi/website の「Allow GitHub Actions to create and approve pull requests」を ON にした  
Settings > Actions > General > Workflow permissions  
https://github.com/organizations/ios-osushi/settings/actions  
https://github.com/ios-osushi/website/settings/actions  
    <img width="993" alt="スクリーンショット 2022-05-05 13 39 58" src="https://user-images.githubusercontent.com/21194714/166864603-3e4beb4e-8a71-42f7-ba9d-51e34f212f4e.png">
- 各ワークフローに必要な権限を明記した
- `hub` を `gh` に置き換えた

## 参考

### 権限

- https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
- https://efcl.info/2021/07/21/update-github-actions-permissions/

### gh

- https://cli.github.com/manual/gh
- https://cli.github.com/manual/gh_pr_create