### PR TITLE
Fix 016

### DIFF
--- a/Content/posts/016-20220718.md
+++ b/Content/posts/016-20220718.md
@@ -57,8 +57,9 @@ Concurrency 対応で、いくつかの修正が入りました。
 
 #### Firebase Apple 9.3.0
 
-[firebase/firebase-ios-sdk](https://github.com/firebase/firebase-ios-sdk/releases/tag/9.3.0)
-[Firebase Apple SDK Release Notes](https://firebase.google.com/support/release-notes/ios#9.3.0)
+[https://github.com/firebase/firebase-ios-sdk/releases/tag/9.3.0](https://github.com/firebase/firebase-ios-sdk/releases/tag/9.3.0)
+
+[https://firebase.google.com/support/release-notes/ios#9.3.0](https://firebase.google.com/support/release-notes/ios#9.3.0)
 
 クラッシュの可能性があった箇所の修正・いくつかの機能が追加されました。
 
@@ -76,12 +77,12 @@ Concurrency 対応に伴い、いくつかの機能が非推奨になりまし�
 
 #### XcodeGen 2.30.0
 
-[yonaskolb/XcodeGen](https://github.com/yonaskolb/XcodeGen/releases/tag/2.30.0)
+[https://github.com/yonaskolb/XcodeGen/releases/tag/2.30.0](https://github.com/yonaskolb/XcodeGen/releases/tag/2.30.0)
 
 Xcode14 向けの対応など、いくつかの修正が入りました。
 
 #### SDWebImage 5.13.1
 
-[SDWebImage/SDWebImage](https://github.com/SDWebImage/SDWebImage/releases/tag/5.13.1)
+[https://github.com/SDWebImage/SDWebImage/releases/tag/5.13.1](https://github.com/SDWebImage/SDWebImage/releases/tag/5.13.1)
 
 いくつかの修正が入りました。

--- a/Content/posts/016-20220718.md
+++ b/Content/posts/016-20220718.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-07-18 09:00
-description: App Store Connect API の詳細がアップデート、Visual Studio Code 向けの Swift Extension を提供、ほか
+description: App Store Connect API 2.0 リリース、VSCode 向けの Swift Extension についての記事が公開、ほか
 tags: visual-studio-code, ios, ipados, tvos, watchos, swiftformat, firebase, apollo, tca
 ---
 # 016 2022-07-18

--- a/Content/posts/016-20220718.md
+++ b/Content/posts/016-20220718.md
@@ -7,6 +7,12 @@ tags: visual-studio-code, ios, ipados, tvos, watchos, swiftformat, firebase, apo
 
 ## App Store Connect API 2.0 リリース
 
+[Automate your workflow with the App Store Connect API](https://developer.apple.com/news/site-updates/?id=07112022a)
+
+[App Store Connect API - サイトの更新情報 - Apple Developer](https://developer.apple.com/jp/news/site-updates/?id=07112022a)
+
+[App Store Connect API 2.0](https://developer.apple.com/news/releases/?id=07112022d)
+
 App Store Connect API 2.0 が利用可能になり、以下が更新されました。
 
 - アプリ内購入
@@ -14,17 +20,11 @@ App Store Connect API 2.0 が利用可能になり、以下が更新されまし
 - カスタマーレビューのサポート
 - 電力とパフォーマンスの改善
 
-[Automate your workflow with the App Store Connect API](https://developer.apple.com/news/site-updates/?id=07112022a)
-
-[App Store Connect API - サイトの更新情報 - Apple Developer](https://developer.apple.com/jp/news/site-updates/?id=07112022a)
-
-[App Store Connect API 2.0](https://developer.apple.com/news/releases/?id=07112022d)
-
 ## VSCode 向けの Swift Extension についての記事が公開
 
-Swift Server Workgroup（SSWG）のメンバーにより、VSCode 向けの Swift Extension についての記事が公開されました。
-
 [Swift Extension for Visual Studio Code](https://www.swift.org/blog/vscode-extension/)
+
+Swift Server Workgroup（SSWG）のメンバーにより、VSCode 向けの Swift Extension についての記事が公開されました。
 
 ## Apple のソフトウェアリリース情報
 


### PR DESCRIPTION
- description を見出しに合わせた
- URL と説明の位置を入れ替えた
- リリースの URL をそのまま表示するようにした