### PR TITLE
huskyを追加

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint
+npm run fix

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint
 npm run fix
+npm run lint

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ iOS OsushiのWebサイトのソースです。
 
 ### セットアップ
 
-1. このプロジェクトをクローンします。  
+1. このプロジェクトをクローンします。
     ```shell
     $ git clone https://github.com/ios-osushi/website.git
     $ cd website
@@ -51,8 +51,10 @@ iOS OsushiのWebサイトのソースです。
 
 ### 校正の実行
 
-`npm run lint` を実行するのみです。  
-`npm run fix` を実行すると自動修正します。
+- `npm run lint` を実行するのみです。
+- `npm run fix` を実行すると自動修正します。
+
+`git commit` をすると上記 2 つは自動で実行されます。
 
 ## 貢献
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "husky": "^8.0.3",
         "textlint": "^12.2.1",
         "textlint-filter-rule-comments": "^1.2.2",
         "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "^1.0.1",
@@ -1194,6 +1195,21 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -5375,6 +5391,12 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
     },
     "inflight": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "husky": "^8.0.3",
     "textlint": "^12.2.1",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "^1.0.1",
@@ -9,6 +10,7 @@
   },
   "scripts": {
     "lint": "npx textlint ./Content/posts/*.md",
-    "fix": "npx textlint --fix ./Content/posts/*.md"
+    "fix": "npx textlint --fix ./Content/posts/*.md",
+    "prepare": "husky install"
   }
 }


### PR DESCRIPTION
Closed #147

# 概要
[husky](https://github.com/typicode/husky)というライブラリを発見しました。
これは、commit や push の際に lint や format など Git Hook を行ってくれる Node.js 製のライブラリです。

## 導入して得られる利益
- 現状は`npm run lint`、`npm run fix`を手動で行っている。
- このツールを導入することでコミット毎に自動でlint、fix を行うことができる
- そのため、PR作成時にCIで足止めされにくくなる

## 使い方
1.  編集した記事をステージします
2. `git commit`すると、直前に`npm`が走ります。(GUIでも同様)

- `npm run fix`→`npm run lint` の順で走ります。
- `lint`が成功したらそのままコミットされます。
- `lint`が失敗した場合、コミットはされず指摘箇所が表示されます。指摘箇所を修正して再度コミットしてください

## 背景
先日、[shiz](https://github.com/stzn)さんの[The Swift Programming Language(日本語版)](https://github.com/stzn/the-swift-programming-language-jp)のPRを作成していた際にこのライブラリを使っていることを知り、

> わい「お、めちゃ便利やん」
> わい「これ、Osushiに提案したろ」

と思ったので提案しました。

