### PR TITLE
記事の連番の採番を既存のポスト数から自動で行う

### DIFF
--- a/.github/workflows/create_post.yml
+++ b/.github/workflows/create_post.yml
@@ -3,10 +3,6 @@ name: "Create post"
 on:
   workflow_dispatch:
     inputs:
-      post_number:
-        description: '3桁の連番。例：001'
-        required: true 
-        type: string
       post_date:
         description: '8桁の投稿日。例：20220404'
         required: true 
@@ -28,17 +24,22 @@ jobs:
         git config --local user.name github-actions[bot]
         git config --local user.email 41898282+github-actions[bot]@users.noreply.github.com
 
+    - name: Set the post number
+      run: |
+        POST_NUMBER=$(($(ls Content/posts | wc -l | awk '{print $1}') - 1))
+        echo "post_number=$POST_NUMBER" >> $GITHUB_ENV
+
     - name: Create and switch work branch
       id: create_work_branch
       run: |
-        WORK_BRANCH_NAME="feature/${{ github.event.inputs.post_number }}_${{ github.event.inputs.post_date }}"
+        WORK_BRANCH_NAME="feature/${{ env.post_number }}_${{ github.event.inputs.post_date }}"
         git switch -c "$WORK_BRANCH_NAME"
         echo "work_branch_name=$WORK_BRANCH_NAME" >> $GITHUB_OUTPUT
 
     - name: Create post
       id: create_post
       run: |
-        POST_FILENAME="${{ github.event.inputs.post_number }}-${{ github.event.inputs.post_date }}.md"
+        POST_FILENAME="${{ env.post_number }}-${{ github.event.inputs.post_date }}.md"
         POST_FILE="./Content/posts/$POST_FILENAME"
         POST_DATE_BEFORE=${{ github.event.inputs.post_date }}
         POST_YEAR=${POST_DATE_BEFORE:0:4}
@@ -46,7 +47,7 @@ jobs:
         POST_DAY=${POST_DATE_BEFORE:6:2}
         POST_DATE=$POST_YEAR-$POST_MONTH-$POST_DAY
         touch $POST_FILE
-        echo -e "---\ndate: $POST_DATE 09:00\ndescription: TBD\ntags: TBD\n---\n# ${{ github.event.inputs.post_number }} $POST_DATE\n\n## TBD\n\n{ニュースなどを書く}\n\n## Apple のソフトウェアリリース情報\n\nApple が提供している OS や IDE のリリース情報です。\n\n### 正式版\n\n- [TBD](TBD)\n\n### 開発者向けベータ\n\n- [TBD](TBD)\n\n## OSS のリリース情報\n\niOS アプリ開発でよく使われている OSS のリリース情報です。\n\n### Apple\n\n#### TBD\n\n[TBD](TBD)\n\nTBD\n\n### サードパーティ\n\n#### TBD\n\n[TBD](TBD)\n\nTBD" > $POST_FILE
+        echo -e "---\ndate: $POST_DATE 09:00\ndescription: TBD\ntags: TBD\n---\n# ${{ env.post_number }} $POST_DATE\n\n## TBD\n\n{ニュースなどを書く}\n\n## Apple のソフトウェアリリース情報\n\nApple が提供している OS や IDE のリリース情報です。\n\n### 正式版\n\n- [TBD](TBD)\n\n### 開発者向けベータ\n\n- [TBD](TBD)\n\n## OSS のリリース情報\n\niOS アプリ開発でよく使われている OSS のリリース情報です。\n\n### Apple\n\n#### TBD\n\n[TBD](TBD)\n\nTBD\n\n### サードパーティ\n\n#### TBD\n\n[TBD](TBD)\n\nTBD" > $POST_FILE
         git add $POST_FILE
         git commit -m "Create $POST_FILENAME"
         git push origin ${{ steps.create_work_branch.outputs.work_branch_name }}


### PR DESCRIPTION
`Content/posts` の中にあるファイル数をもとに、`create_post.yml` 実行時の採番を自動で行う。

動作確認（`118-20240916.md` まである状態で実行し、「119」番が作られている、#208 として生成に成功している）:
![スクリーンショット 2024-09-28 18 24 15](https://github.com/user-attachments/assets/74fd0ad7-725b-45e7-9afd-bab4318e51a0)
